### PR TITLE
0.2.0.0 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ matrix:
   #    compiler: ": #stack default"
   #    addons: {apt: {packages: [libgmp-dev]}}
 
+  - env: BUILD=stack ARGS="--resolver lts-6 --stack-yaml stack-lts-13.yaml"
+    compiler: ": #stack 7.10.3"
+    addons: {apt: {packages: [libgmp-dev]}}
+
   - env: BUILD=stack ARGS="--resolver lts-7 --stack-yaml stack-lts-13.yaml"
     compiler: ": #stack 8.0.1"
     addons: {apt: {packages: [libgmp-dev]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,9 @@ before_install:
     travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
   else
     # recent versions of stack fail to work with lts <= 7
-    if [[ $ARGS == *"lts-7"* ]]; then
+    # but we don't expect to build with lts <= 5, so just 2 checks
+    # to do.
+    if [[ $ARGS == *"lts-7"* || $ARGS == *"lts-6"* ]]; then
       url=https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz
     else
       url=https://get.haskellstack.org/stable/linux-x86_64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,7 @@ before_install:
     travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
   else
     # recent versions of stack fail to work with lts <= 7
-    # but we don't expect to build with lts <= 5, so just 2 checks
-    # to do.
-    if [[ $ARGS == *"lts-7"* || $ARGS == *"lts-6"* ]]; then
+    if [[ $ARGS == *"lts-7"* ]]; then
       url=https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz
     else
       url=https://get.haskellstack.org/stable/linux-x86_64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ matrix:
   #    compiler: ": #stack default"
   #    addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-6 --stack-yaml stack-lts-13.yaml"
-    compiler: ": #stack 7.10.3"
-    addons: {apt: {packages: [libgmp-dev]}}
-
   - env: BUILD=stack ARGS="--resolver lts-7 --stack-yaml stack-lts-13.yaml"
     compiler: ": #stack 8.0.1"
     addons: {apt: {packages: [libgmp-dev]}}

--- a/exigo-schema.cabal
+++ b/exigo-schema.cabal
@@ -19,9 +19,8 @@ extra-source-files:
     stack-lts-13.yaml
     config/exigo.persistentmodels
     .travis.yml
--- builds & tests successfully as far back as stack lts-7
-tested-with:         GHC == 7.10.3
-                     GHC == 8.0.1
+-- builds & tests successfully as far back as stack lts-7/ghc-8.0
+tested-with:         GHC == 8.0.1
                      GHC == 8.2.2
                      GHC == 8.6.5
 
@@ -38,7 +37,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.0 && <5
+      base >=4.9 && <5
     , aeson
     , binary
     , bytestring

--- a/exigo-schema.cabal
+++ b/exigo-schema.cabal
@@ -16,9 +16,12 @@ build-type:     Simple
 extra-source-files:
     README.md
     ChangeLog.md
+    stack-lts-13.yaml
     config/exigo.persistentmodels
+    .travis.yml
 -- builds & tests successfully as far back as stack lts-7
-tested-with:         GHC == 8.0.1
+tested-with:         GHC == 7.10.3
+                     GHC == 8.0.1
                      GHC == 8.2.2
                      GHC == 8.6.5
 
@@ -48,14 +51,15 @@ library
   ghc-options:
       -Wall
       -fwarn-tabs
-      -Wredundant-constraints
-      -Wno-type-defaults
-      -Wcompat
-      -Wextra
-      -Widentities
-      -Wincomplete-record-updates
-      -Wincomplete-uni-patterns
-      -Wno-name-shadowing
+  if impl(ghc >= 8.0)
+    ghc-options:        -Wredundant-constraints
+                        -Wno-type-defaults
+                        -Wcompat
+                        -Widentities
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-name-shadowing
+                        -Wextra
   if impl(ghc >= 8.2)
     ghc-options:        -fhide-source-paths
   if impl(ghc >= 8.4)


### PR DESCRIPTION
Tighten bounds so that base >= 4.9/ghc >= 8.0 is required (else, `-XDeriveLift` would not be availabled).

Don't attempt CI builds of lts-6 (or earlier).
